### PR TITLE
GetFileInfo should not throw if the file does not exist

### DIFF
--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobFileInfo.cs
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobFileInfo.cs
@@ -11,22 +11,33 @@ namespace Strathweb.AspNetCore.AzureBlobFileProvider
 
         public AzureBlobFileInfo(IListBlobItem blob)
         {
-            Exists = true;
             switch (blob)
             {
                 case CloudBlobDirectory d:
+                    Exists = true;
                     IsDirectory = true;
                     Name = ((CloudBlobDirectory)blob).Prefix.TrimEnd('/');
                     PhysicalPath = d.StorageUri.PrimaryUri.ToString();
                     break;
 
                 case CloudBlockBlob b:
-                    b.FetchAttributes();
-                    Length = b.Properties.Length;
-                    PhysicalPath = b.Uri.ToString();
-                    Name = !string.IsNullOrEmpty(b.Parent.Prefix) ? b.Name.Replace(b.Parent.Prefix, "") : b.Name;
-                    LastModified = b.Properties.LastModified ?? DateTimeOffset.MinValue;
                     _blockBlob = b;
+                    Name = !string.IsNullOrEmpty(b.Parent.Prefix) ? b.Name.Replace(b.Parent.Prefix, "") : b.Name;
+                    Exists = b.Exists();
+                    if (Exists)
+                    {
+                        b.FetchAttributes();
+                        Length = b.Properties.Length;
+                        PhysicalPath = b.Uri.ToString();
+                        LastModified = b.Properties.LastModified ?? DateTimeOffset.MinValue;
+                    }
+                    else
+                    {
+                        Length = -1;
+                        // IFileInfo.PhysicalPath docs say: Return null if the file is not directly accessible.
+                        // (PhysicalPath should maybe also be null for blobs that do exist but that would be a potentially breaking change.)
+                        PhysicalPath = null;
+                    }
                     break;
             }
         }


### PR DESCRIPTION
AzureBlobFileProvider.GetFileInfo(string subpath) should not throw if the file does not exist.
Instead it should return an IFileInfo object with property Exists == false.

Fixes: https://github.com/filipw/Strathweb.AspNetCore.AzureBlobFileProvider/issues/13