### PR TITLE
Update Azure Storage Blob package to 11.1.0

### DIFF
--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobDirectoryContents.cs
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobDirectoryContents.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Strathweb.AspNetCore.AzureBlobFileProvider
 {

--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobFileInfo.cs
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/AzureBlobFileInfo.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.FileProviders;
-using Microsoft.WindowsAzure.Storage.Blob;
-using System;
+﻿using System;
 using System.IO;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Extensions.FileProviders;
 
 namespace Strathweb.AspNetCore.AzureBlobFileProvider
 {

--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/DefaultBlobContainerFactory.cs
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/DefaultBlobContainerFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
 
 namespace Strathweb.AspNetCore.AzureBlobFileProvider
 {

--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/IBlobContainerFactory.cs
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/IBlobContainerFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.WindowsAzure.Storage.Blob;
+﻿using Microsoft.Azure.Storage.Blob;
 
 namespace Strathweb.AspNetCore.AzureBlobFileProvider
 {

--- a/src/Strathweb.AspNetCore.AzureBlobFileProvider/Strathweb.AspNetCore.AzureBlobFileProvider.csproj
+++ b/src/Strathweb.AspNetCore.AzureBlobFileProvider/Strathweb.AspNetCore.AzureBlobFileProvider.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just a small PR to update the Azure Storage Blob package to 11.1.0.

The current Azure Storage Blob version 9.4.2 depends on Microsoft.Azure.KeyVault.Core 1.0.0, which gives us this warning when compiling apps that depend on **this** project:

`warning NU1701: Package 'Microsoft.Azure.KeyVault.Core 1.0.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETCoreApp,Version=v2.1'. This package may not be fully compatible with your project.`

By updating the Blob package to 11.1.0, it depends on a later version of Azure.KeyVault that targets .NET Standard 2.0 properly, so the warning goes away.

There is a newer version of the Azure Storage Blob package that's _very_ recently been released ([v12](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Azure.Storage.Blobs)), however this is more of a rewrite from the ground up, where the API has been completely redesigned. So in the meantime, I opted for this simpler stepping stone to 11.1.0 (which is still documented on the Azure docs).